### PR TITLE
Use this.cssclass

### DIFF
--- a/core/respond-form-field.html
+++ b/core/respond-form-field.html
@@ -163,7 +163,7 @@
 			div.setAttribute('data-label', this.label);
 			div.setAttribute('data-type', this.type);
 			div.setAttribute('data-required', this.required);
-			div.setAttribute('class', 'form-group');
+			div.setAttribute('class', 'form-group ' + this.cssclass);
 			div.innerHTML = html;
 
 			// append to the light dom


### PR DESCRIPTION
When you want to add a custom class to element with form-group it is not applied because it is not used.
